### PR TITLE
Fix anchor tag

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -6,7 +6,7 @@
 
   <description><![CDATA[
       A PhpStorm plugin for CodeIgniter 3 development.
-      Plugin is a fork of <a href="https://github.com/martynassateika/CodeIgniter-phpstorm-plugin">plugin</a> by <a href="url="http://www.martynassateika.lt">Martynas Sateika</a> 
+      Plugin is a fork of <a href="https://github.com/martynassateika/CodeIgniter-phpstorm-plugin">plugin</a> by <a href="https://www.martynassateika.lt">Martynas Sateika</a> 
       and <a href="https://github.com/natanfelles/codeigniter-phpstorm">helpers</a> from <a href="https://natanfelles.github.io/">Natan Felles</a>.
     ]]></description>
 


### PR DESCRIPTION
Just noticed the anchor tag was set up incorrectly, and so the link doesn't work in the plugin's page in the JetBrains repository. Fixing, and making it use the HTTPS protocol.